### PR TITLE
Massive refactor of the database interface in the image manager.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - cd ../..
   - export ORIGPATH=$PATH
   - export PATH=$PWD/imagegw/test:$PATH
-  - PYTHONPATH=$PWD/imagegw nosetests -s --with-coverage imagegw/test
+  - PYTHONPATH=$PWD/imagegw nosetests -s -v --with-coverage imagegw/test
   - export PATH=$ORIGPATH
   - export BUILDDIR=$(pwd)
   - cd /

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ after_failure:
   - ls -latrh /tmp/*
   - ls -latrh /tmp/imagegw/*
   - ls -latrh /tmp/systema/images/*
-  - cat /tmp/worker.log
+  - cat /var/log/shifter_imagegw/error.log
 after_success:
   - cpp-coveralls --exclude dep -n --dump cpp_coveralls.json
   - coveralls-merge cpp_coveralls.json 

--- a/extra/CI/integration_test.sh
+++ b/extra/CI/integration_test.sh
@@ -53,9 +53,6 @@ sudo service munge start
 echo "Starting imagegw api"
 gunicorn -b 0.0.0.0:5000 --backlog 2048 --access-logfile=/var/log/shifter_imagegw/access.log --log-file=/var/log/shifter_imagegw/error.log shifter_imagegw.api:app &
 
-echo "Starting image worker"
-celery -A shifter_imagegw.imageworker worker -Q mycluster -n mycluster.%h --loglevel=debug --logfile=/var/log/shifter_imagegw_worker/mycluster.log &
-
 echo "setting up base config"
 sudo /bin/bash -c "cat /etc/shifter/udiRoot.conf.example | \
          sed 's|etcPath=.*|etcPath=/etc/shifter/shifter_etc_files|g' | \

--- a/imagegw/shifter_imagegw/Makefile.am
+++ b/imagegw/shifter_imagegw/Makefile.am
@@ -2,6 +2,7 @@ shifter_imagegw_PYTHON = auth.py \
 				api.py \
 				converters.py \
 				dockerv2.py \
+				images.py \
 				imagemngr.py \
 				imageworker.py \
 				__init__.py \

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -340,7 +340,6 @@ class DockerV2Handle(object):
 
         headers = {}
         if creds and self.username is not None and self.password is not None:
-            print "\nUsing Usernmae/Password: private set to True\n"
             self.private = True
             auth = '%s:%s' % (self.username, self.password)
             headers['Authorization'] = 'Basic %s' % base64.b64encode(auth)
@@ -357,7 +356,7 @@ class DockerV2Handle(object):
 
         if resp.status != 200:
             raise ValueError('Bad response getting token: %d', resp.status)
-        if resp.getheader('content-type') != 'application/json':
+        if not resp.getheader('content-type').startswith('application/json'):
             raise ValueError('Invalid response getting token, not json')
 
         auth_resp = json.loads(resp.read())
@@ -381,6 +380,8 @@ class DockerV2Handle(object):
         self._get_auth_header()
 
         req_path = "/v2/%s/manifests/%s" % (self.repo, self.tag)
+        # conn.set_debuglevel(9)
+
         conn.request("GET", req_path, None, self.headers)
         resp1 = conn.getresponse()
 
@@ -697,6 +698,7 @@ def main():
     cache_dir = os.environ['TMPDIR']
     pull_image({'baseUrl': 'https://registry-1.docker.io'}, 'scanon/shanetest',
                'latest', cachedir=cache_dir, expanddir=cache_dir)
+
 
 if __name__ == '__main__':
     main()

--- a/imagegw/shifter_imagegw/images.py
+++ b/imagegw/shifter_imagegw/images.py
@@ -1,0 +1,237 @@
+from pymongo import MongoClient
+import pymongo.errors
+from time import sleep, time
+
+# This module should abstracts all of the database interactions.
+#
+
+
+# decorator function to re-attempt any mongo operation that may have failed
+# owing to AutoReconnect (e.g., mongod coming back, etc).  This may increase
+# the opportunity for race conditions, and should be more closely considered
+# for the insert/update functions
+def mongo_reconnect_reattempt(call):
+    """Automatically re-attempt potentially failed mongo operations"""
+    def _mongo_reconnect_safe(self, *args, **kwargs):
+        for _ in xrange(2):
+            try:
+                return call(self, *args, **kwargs)
+            except pymongo.errors.AutoReconnect:
+                # self.logger.warn("Error: mongo reconnect attmempt")
+                sleep(2)
+        # self.logger.warn("Error: Failed to deal with mongo auto-reconnect!")
+        raise OSError('Reconnect to mongo failed')
+    return _mongo_reconnect_safe
+
+
+class Images(object):
+    def __init__(self, mongo_uri, mongo_db, metrics=False,
+                 update_timeout=300):
+        client = MongoClient(mongo_uri)
+        self.images = client[mongo_db].images
+        self.pullupdatetimeout = update_timeout
+        if metrics:
+            self.metrics = client[mongo_db].metrics
+        else:
+            self.metrics = None
+
+    def get_image_by_id(self, ident):
+        return self._images_find_one({'_id': ident})
+
+    def get_image_by_imageid(self, imageid, system, status=None):
+        q = {'id': imageid, 'system': system}
+        if status is not None:
+            q['status'] = 'READY'
+        return self._images_find_one(q)
+
+    def get_image_by_tag(self, image, status='READY'):
+        query = {
+            'status': status,
+            'system': image['system'],
+            'itype': image['itype'],
+            'tag': {'$in': [image['tag']]}
+        }
+        rec = self._images_find_one(query)
+        return rec
+
+    def get_images(self, system, status='READY'):
+        q = dict()
+        if system is not None:
+            q['system'] = system
+        q['status'] = status
+        # Special status
+        if status == "NOT_READY":
+            q['status'] = {'$ne': 'READY'}
+        results = []
+        for image in self._images_find(q):
+            results.append(image)
+
+        return results
+
+    def get_images_by_pulltag(self, image):
+        q = {
+            'system': image['system'],
+            'itype': image['itype'],
+            'pulltag': image['pulltag']
+        }
+        resp = []
+        for rec in self._images_find(q):
+            resp.append(rec)
+        return resp
+
+    def insert_image(self, image):
+        # Clean out any existing records
+        q = {
+            'system': image['system'],
+            'itype': image['itype'],
+            'pulltag': image['pulltag']
+        }
+        for rec in self._images_find(q):
+            if rec['status'] == 'READY':
+                continue
+            else:
+                self.images.remove_image_by_id(rec['id'])
+        return self._images_insert(image)
+
+    def remove_image_by_id(self, ident):
+        self._images_remove({'_id': ident})
+
+    def update_image_state(self, ident, state, info=None):
+        """
+        Helper function to set the mongo state for an image with _id==ident
+        to state=state.
+        """
+        if state == 'SUCCESS':
+            state = 'READY'
+        set_list = {'status': state, 'status_message': ''}
+        if info is not None and isinstance(info, dict):
+            if 'heartbeat' in info:
+                set_list['last_heartbeat'] = info['heartbeat']
+            if 'message' in info:
+                set_list['status_message'] = info['message']
+        return self._images_update({'_id': ident}, {'$set': set_list})
+
+    def get_state(self, ident):
+        """
+        Lookup the state of the image with _id==ident in Mongo.
+        Returns the state.
+        """
+        rec = self._images_find_one({'_id': ident}, {'status': 1})
+        if rec is None:
+            return None
+        elif 'status' not in rec:
+            return None
+        return rec['status']
+
+    def reset_image_expire(self, ident, expire):
+        """Reset the expire time.  (Not fully implemented)."""
+        self._images_update({'_id': ident}, {'$set': {'expiration': expire}})
+
+    def add_tag(self, ident, system, tag):
+        """
+        Helper function to add a tag to an image.
+        ident is the mongo id (not image id)
+        """
+        # Remove the tag first
+        self.remove_tag(system, tag)
+        # see if tag isn't a list
+        rec = self._images_find_one({'_id': ident})
+        if rec is not None and 'tag' in rec and \
+                not isinstance(rec['tag'], (list)):
+            # memo = 'Fixing tag for non-list %s %s' % (ident, str(rec['tag']))
+            curtag = rec['tag']
+            self._images_update({'_id': ident}, {'$set': {'tag': [curtag]}})
+        self._images_update({'_id': ident}, {'$addToSet': {'tag': tag}})
+        return True
+
+    def remove_tag(self, system, tag):
+        """
+        Helper function to remove a tag to an image.
+        """
+        self._images_update({'system': system, 'tag': {'$in': [tag]}},
+                            {'$pull': {'tag': tag}}, multi=True)
+        return True
+
+    def update_image_last_pull(self, ident, time=time()):
+        self.update_mongo(ident, {'last_pull': time})
+
+    def update_states(self):
+        """
+        Cleanup failed transcations after a period
+        """
+        for rec in self._images_find({'status': 'FAILURE'}):
+            nextpull = self.pullupdatetimeout + rec['last_pull']
+            # It it has been a while then let's clean up
+            if time() > nextpull:
+                self._images_remove({'_id': rec['_id']})
+
+    def update_mongo(self, ident, resp):
+        """
+        Helper function to set the mongo values for an image with _id==ident.
+        """
+        setline = dict()
+        # This maps from the key name in the response to the
+        # key name used in mongo
+        mappings = {
+            'id': 'id',
+            'entrypoint': 'ENTRY',
+            'env': 'ENV',
+            'workdir': 'WORKDIR',
+            'last_pull': 'last_pull',
+            'userACL': 'userACL',
+            'groupACL': 'groupACL',
+            'private': 'private',
+            'state': 'status'
+        }
+        if 'private' in resp and resp['private'] is False:
+            resp['userACL'] = []
+            resp['groupACL'] = []
+
+        for key in mappings.keys():
+            if key in resp:
+                setline[mappings[key]] = resp[key]
+        self._images_update({'_id': ident}, {'$set': setline})
+
+    def get_metrics(self, system, limit):
+        if self.metrics is None:
+            return []
+        count = self.metrics.count()
+        skip = count - limit
+        if skip < 0:
+            skip = 0
+        recs = []
+        for r in self.metrics.find().skip(skip):
+            r.pop('_id', None)
+            recs.append(r)
+        return recs
+
+    @mongo_reconnect_reattempt
+    def _images_remove(self, *args, **kwargs):
+        """ Decorated function to remove images from mongo """
+        return self.images.remove(*args, **kwargs)
+
+    @mongo_reconnect_reattempt
+    def _images_update(self, *args, **kwargs):
+        """ Decorated function to updates images in mongo """
+        return self.images.update(*args, **kwargs)
+
+    @mongo_reconnect_reattempt
+    def _images_find(self, *args, **kwargs):
+        """ Decorated function to find images in mongo """
+        return self.images.find(*args, **kwargs)
+
+    @mongo_reconnect_reattempt
+    def _images_find_one(self, *args, **kwargs):
+        """ Decorated function to find one image in mongo """
+        return self.images.find_one(*args, **kwargs)
+
+    @mongo_reconnect_reattempt
+    def _images_insert(self, *args, **kwargs):
+        """ Decorated function to insert an image in mongo """
+        return self.images.insert(*args, **kwargs)
+
+    @mongo_reconnect_reattempt
+    def _metrics_insert(self, *args, **kwargs):
+        """ Decorated function to insert an image in mongo """
+        if self.metrics is not None:
+            return self.metrics.insert(*args, **kwargs)

--- a/imagegw/test/dockerv2_test.py
+++ b/imagegw/test/dockerv2_test.py
@@ -43,7 +43,7 @@ class Dockerv2TestCase(unittest.TestCase):
         self.cleanpaths.append(cache)
         self.cleanpaths.append(expand)
 
-        resp = dockerv2.pull_image(self.options, 'dmjacobsen/whiteouttest',
+        resp = dockerv2.pull_image(self.options, 'scanon/whiteouttest',
                                    'latest', cachedir=cache, expanddir=expand)
 
         assert os.path.exists(resp['expandedpath'])

--- a/imagegw/test/imagegwapi_test.py
+++ b/imagegw/test/imagegwapi_test.py
@@ -98,7 +98,7 @@ class GWTestCase(unittest.TestCase):
                 break
             if r['status'] == 'FAILURE':
                 break
-            print '  %s...' % (r['status'])
+            print '  %3d %s...' % (count, r['status'])
             time.sleep(1)
             count = count - 1
         return rv

--- a/imagegw/test/imagegwapi_test.py
+++ b/imagegw/test/imagegwapi_test.py
@@ -48,7 +48,7 @@ class GWTestCase(unittest.TestCase):
         system = self.system
         self.imageDir = self.config['Platforms'][system]['ssh']['imageDir']
         self.type = "docker"
-        self.itag = "ubuntu:14.04"
+        self.itag = "alpine:latest"
         self.tag = urllib.quote(self.itag)
         self.urlreq = "%s/%s/%s" % (self.system, self.type, self.tag)
         # Need to switch to real munge tokens

--- a/imagegw/test/imagegwapi_test.py
+++ b/imagegw/test/imagegwapi_test.py
@@ -81,7 +81,7 @@ class GWTestCase(unittest.TestCase):
                 if os.path.exists(fp):
                     os.remove(fp)
 
-    def time_wait_pull(self, urlreq, state='READY', TIMEOUT=30, data=None):
+    def time_wait_pull(self, urlreq, state='READY', TIMEOUT=200, data=None):
         poll_interval = 0.5
         count = TIMEOUT / poll_interval
         cstate = 'UNKNOWN'

--- a/imagegw/test/imagemngr_test.py
+++ b/imagegw/test/imagemngr_test.py
@@ -55,7 +55,7 @@ class ImageMngrTestCase(unittest.TestCase):
         self.id = 'fakeid'
         self.tag2 = 'test2'
         self.tag3 = 'scanon/shanetest:latest'
-        self.public = 'index.docker.io/busybox:latest'
+        self.public = 'index.docker.io/alpine:latest'
         self.private = 'index.docker.io/scanon/shaneprivate:latest'
         self.format = 'squashfs'
         self.auth = 'good:user:user::100:100'

--- a/imagegw/test/imagemngr_test.py
+++ b/imagegw/test/imagemngr_test.py
@@ -78,7 +78,7 @@ class ImageMngrTestCase(unittest.TestCase):
         """
         self.m.shutdown()
 
-    def time_wait(self, id, wstate='READY', TIMEOUT=30):
+    def time_wait(self, id, wstate='READY', TIMEOUT=200):
         poll_interval = 0.5
         count = TIMEOUT / poll_interval
         state = 'UNKNOWN'

--- a/imagegw/test/images_test.py
+++ b/imagegw/test/images_test.py
@@ -1,0 +1,293 @@
+import unittest
+from time import time
+import json
+from pymongo import MongoClient
+
+"""
+Shifter, Copyright (c) 2015, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ 3. Neither the name of the University of California, Lawrence Berkeley
+    National Laboratory, U.S. Dept. of Energy nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.`
+
+See LICENSE for full text.
+"""
+
+
+class ImagesTestCase(unittest.TestCase):
+
+    def setUp(self):
+        from shifter_imagegw.images import Images
+        self.configfile = 'test.json'
+        with open(self.configfile) as config_file:
+            self.config = json.load(config_file)
+        mongodb = self.config['MongoDBURI']
+        client = MongoClient(mongodb)
+        db = self.config['MongoDB']
+        self.images = client[db].images
+        self.metrics = client[db].metrics
+        self.images.drop()
+        self.m = Images(mongodb, db, metrics=True)
+        self.system = 'systema'
+        self.itype = 'docker'
+        self.tag = 'test'
+        self.id = 'fakeid'
+        self.tag2 = 'test2'
+        self.tag3 = 'scanon/shanetest:latest'
+        self.public = 'index.docker.io/busybox:latest'
+        self.private = 'index.docker.io/scanon/shaneprivate:latest'
+        self.format = 'squashfs'
+        self.auth = 'good:user:user::100:100'
+        self.authadmin = 'good:root:root::0:0'
+        self.badauth = 'bad:user:user::100:100'
+        self.logfile = '/tmp/worker.log'
+        self.pid = 0
+        self.query = {'system': self.system, 'itype': self.itype,
+                      'tag': self.tag}
+        # Cleanup Mongo
+        self.images.remove({})
+
+    def tearDown(self):
+        """
+        tear down should stop the worker
+        """
+        pass
+
+    def good_pullrecord(self):
+        return {'system': self.system,
+                'itype': self.itype,
+                'id': self.id,
+                'pulltag': self.tag,
+                'status': 'READY',
+                'userACL': [],
+                'groupACL': [],
+                'ENV': [],
+                'ENTRY': '',
+                'last_pull': time()
+                }
+
+    def good_record(self):
+        return {
+            'system': self.system,
+            'itype': self.itype,
+            'id': self.id,
+            'tag': [self.tag],
+            'format': self.format,
+            'status': 'READY',
+            'userACL': [],
+            'groupACL': [],
+            'last_pull': time(),
+            'ENV': [],
+            'ENTRY': ''
+        }
+
+    def set_last_pull(self, id, t):
+        self.m.images.update({'_id': id}, {'$set': {'last_pull': t}})
+
+#
+#  Tests
+#
+
+# Create an image and tag with a new tag.
+# Make sure both tags show up.
+# Remove the tag and make sure the original tags
+# doesn't also get removed.
+    def test_0add_remove_tag(self):
+        record = self.good_record()
+        # Create a fake record in mongo
+        id = self.images.insert(record)
+
+        assert id is not None
+        before = self.images.find_one({'_id': id})
+        assert before is not None
+        # Add a tag a make sure it worked
+        status = self.m.add_tag(id, self.system, 'testtag')
+        assert status is True
+        after = self.images.find_one({'_id': id})
+        assert after is not None
+        assert after['tag'].count('testtag') == 1
+        assert after['tag'].count(self.tag) == 1
+        # Remove a tag and make sure it worked
+        status = self.m.remove_tag(self.system, 'testtag')
+        assert status is True
+        after = self.images.find_one({'_id': id})
+        assert after is not None
+        assert after['tag'].count('testtag') == 0
+
+    # Similar to above but just test the adding part
+    def test_0add_remove_tagitem(self):
+        record = self.good_record()
+        record['tag'] = self.tag
+        # Create a fake record in mongo
+        id = self.images.insert(record)
+
+        status = self.m.add_tag(id, self.system, 'testtag')
+        assert status is True
+        rec = self.images.find_one({'_id': id})
+        assert rec is not None
+        assert rec['tag'].count(self.tag) == 1
+        assert rec['tag'].count('testtag') == 1
+
+    # Same as above but use the lookup instead of a directory
+    # direct mongo lookup
+    def test_0add_remove_withtag(self):
+        record = self.good_record()
+        # Create a fake record in mongo
+        id = self.images.insert(record)
+
+        status = self.m.add_tag(id, self.system, 'testtag')
+        assert status is True
+        rec = self.m.get_image_by_id(id)
+        assert rec is not None
+        assert rec['tag'].count(self.tag) == 1
+        assert rec['tag'].count('testtag') == 1
+
+    # Test if tag isn't a list
+    def test_0add_remove_two(self):
+        record = self.good_record()
+        # Create a fake record in mongo
+        id1 = self.images.insert(record.copy())
+        record['id'] = 'fakeid2'
+        record['tag'] = []
+        id2 = self.images.insert(record.copy())
+
+        status = self.m.add_tag(id2, self.system, self.tag)
+        assert status is True
+        rec1 = self.images.find_one({'_id': id1})
+        rec2 = self.images.find_one({'_id': id2})
+        assert rec1['tag'].count(self.tag) == 0
+        assert rec2['tag'].count(self.tag) == 1
+
+    # Similar to above but just test the adding part
+    def test_0add_same_image_two_system(self):
+        record = self.good_record()
+        record['tag'] = self.tag
+        # Create a fake record in mongo
+        id1 = self.images.insert(record.copy())
+        # add testtag for systema
+        status = self.m.add_tag(id1, self.system, 'testtag')
+        assert status is True
+        record['system'] = 'systemb'
+        id2 = self.images.insert(record.copy())
+        status = self.m.add_tag(id2, 'systemb', 'testtag')
+        assert status is True
+        # Now make sure testtag for first system is still
+        # present
+        rec = self.images.find_one({'_id': id1})
+        assert rec is not None
+        assert rec['tag'].count('testtag') == 1
+
+    def test_0resetexp(self):
+        record = {'system': self.system,
+                  'itype': self.itype,
+                  'id': self.id,
+                  'pulltag': self.tag,
+                  'status': 'READY',
+                  'userACL': [],
+                  'groupACL': [],
+                  'ENV': [],
+                  'ENTRY': '',
+                  'last_pull': 0
+                  }
+        id = self.images.insert(record.copy())
+        assert id is not None
+        expire = time() + 1000
+        self.m.reset_image_expire(id, expire)
+        rec = self.images.find_one({'_id': id})
+        assert rec['expiration'] == expire
+
+    def test_0update_image_states(self):
+        # Test a repull
+        record = self.good_record()
+        # Create a fake record in mongo
+        id = self.images.insert(record)
+        assert id is not None
+        status = 'TESTME'
+        self.m.update_image_state(id, status)
+        rec = self.images.find_one({'_id': id})
+        self.assertIsNotNone(rec)
+        self.assertEquals(rec['status'], status)
+
+    def test_0update_states(self):
+        # Test a repull
+        record = self.good_record()
+        record['last_pull'] = 0
+        record['status'] = 'FAILURE'
+        # Create a fake record in mongo
+        id = self.images.insert(record)
+        assert id is not None
+        self.m.update_states()
+        rec = self.images.find_one({'_id': id})
+        assert rec is None
+
+    def test_lookup(self):
+        record = self.good_record()
+        record['expiration'] = time()+100
+        # Create a fake record in mongo
+        self.images.insert(record)
+        myid = record['id']
+        system = record['system']
+        l = self.m.get_image_by_imageid(myid, system)
+        assert 'status' in l
+        assert '_id' in l
+        assert self.m.get_state(l['_id']) == 'READY'
+        i = self.query.copy()
+        r = self.images.find_one({'_id': l['_id']})
+        assert 'expiration' in r
+        assert r['expiration'] > time()
+        i['tag'] = 'bogus'
+        l = self.m.get_image_by_id(i)
+        assert l is None
+
+    def test_insert_image(self):
+        pass
+
+    def test_list(self):
+        record = self.good_record()
+        # Create a fake record in mongo
+        id1 = self.images.insert(record.copy())
+        # rec2 is a failed pull, it shouldn't be listed
+        rec2 = record.copy()
+        rec2['status'] = 'FAILURE'
+        li = self.m.get_images(self.system)
+        assert len(li) == 1
+        l = li[0]
+        assert '_id' in l
+        assert self.m.get_state(l['_id']) == 'READY'
+        assert l['_id'] == id1
+
+    def test_metrics(self):
+        rec = {
+            "uid": 100,
+            "user": "usera",
+            "tag": self.tag,
+            "system": self.system,
+            "id": self.id,
+            "type": self.itype
+        }
+        # Remove everything
+        self.metrics.remove({})
+        for _ in xrange(100):
+            rec['time'] = time()
+            self.metrics.insert(rec.copy())
+        recs = self.m.get_metrics(self.system, 10)  # ,delay=False)
+        self.assertIsNotNone(recs)
+        self.assertEquals(len(recs), 10)
+        # Try pulling more records than we have
+        recs = self.m.get_metrics(self.system, 101)  # ,delay=False)
+        self.assertIsNotNone(recs)
+        self.assertEquals(len(recs), 100)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/imagegw/test/imageworker_test.py
+++ b/imagegw/test/imageworker_test.py
@@ -41,7 +41,7 @@ class ImageWorkerTestCase(unittest.TestCase):
         self.system = 'systema'
         self.itype = 'docker'
         self.tag = 'registry.services.nersc.gov/nersc-py:latest'
-        self.tag = 'ubuntu:latest'
+        self.tag = 'alpine:latest'
         self.tag = 'scanon/shanetest:latest'
         self.hash = \
             'b3491cdefcdb79a31ab7ddf1bbcf7c8eeff9b4f00cb83a0be513fb800623f9cf'
@@ -62,9 +62,9 @@ class ImageWorkerTestCase(unittest.TestCase):
         self.imageDir = idir
 
     def cleanup_cache(self):
-        for h in [self.hash, self.hash2, self.hash3]:
-            for ext in ['meta', 'squashfs']:
-                fp = '%s/%s.%s' % (self.imageDir, h, ext)
+        for f in os.listdir(self.imageDir):
+            if f.endswith('.meta') or f.endswith('.squashfs'):
+                fp = '%s/%s' % (self.imageDir, f)
                 if os.path.exists(fp):
                     os.remove(fp)
 
@@ -107,7 +107,7 @@ class ImageWorkerTestCase(unittest.TestCase):
         request = {
             'system': self.system,
             'itype': self.itype,
-            'tag': 'index.docker.io/ubuntu:latest'
+            'tag': 'index.docker.io/alpine:latest'
         }
         status = self.imageworker.pull_image(request, self.updater)
         self.assertTrue(status)
@@ -115,7 +115,6 @@ class ImageWorkerTestCase(unittest.TestCase):
         meta = request['meta']
         self.assertIn('id', meta)
         self.assertTrue(os.path.exists(request['expandedpath']))
-        return
 
     # Use the URL format of the location, like an alias
     def test_pull_image_url(self):


### PR DESCRIPTION
All of the db interactions were extracted into a separate images
module.  This is laying the ground work for replacing the db with
other options besides mongo.

In addition, many of the assertion tests in the test script were
replaced with the unit test variant which emits pretty messages on
failure.  Also, cache cleaning and other state resets were added
so that tests wouldn't falsely fail from one test to the next.